### PR TITLE
Assistant checkpoint: Fix Open Graph image paths and build config

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,9 @@
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Bonkeez NFT Exchange - Trade $BNKZ Token on Solana" />
     <meta property="og:description" content="The ultimate marketplace for Bonkeez NFTs on Solana with $BNKZ token integration" />
-    <meta property="og:image" content="/bonk.JPG" />
+    <meta property="og:image" content="https://bonkeez.exchange/bonk.JPG" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:url" content="https://bonkeez.exchange" />
     <meta property="og:type" content="website" />
     
@@ -22,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Bonkeez NFT Exchange - Trade $BNKZ Token on Solana" />
     <meta name="twitter:description" content="The ultimate marketplace for Bonkeez NFTs on Solana with $BNKZ token integration" />
-    <meta name="twitter:image" content="/bonk.JPG" />
+    <meta name="twitter:image" content="https://bonkeez.exchange/bonk.JPG" />
     <meta name="twitter:site" content="@bonkeez_nft" />
     
     <!-- Additional Meta Tags -->

--- a/vite.config.js
+++ b/vite.config.js
@@ -54,5 +54,6 @@ export default defineConfig({
     },
     target: "esnext",
     assetsDir: "assets",
+    copyPublicDir: true,
   },
 });


### PR DESCRIPTION
Assistant generated file changes:
- index.html: Update Open Graph image to use absolute URL
- vite.config.js: Ensure public assets are properly copied

---

User prompt:

On telegram it still shows that chat and build image oo then on x it shouldn't no image then on what's it should the @public/bonk.JPG .

I want the bonk.jpg should be what it is in the website.

Kindly look beyond just the index.html page and tell me why

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: ba63ccd2-f5c8-40b2-b424-49a8ab0b1450